### PR TITLE
Add Python script to update BrickLink Studio's Dark Blue

### DIFF
--- a/lego/update-studio-dark-blue.py
+++ b/lego/update-studio-dark-blue.py
@@ -1,0 +1,25 @@
+import csv
+import os
+
+filename = os.path.expanduser("~/.local/share/Stud.io/CustomColorDefinition.txt")
+out_file = filename + ".out.txt"
+
+
+def update_row(row):
+    if row['Studio Color Code'] == "63":
+        row['Ins_RGB'] = '#013B6D'
+    return row
+
+
+with open(filename, newline='') as tsv_input, open(out_file, 'w', newline='') as tsv_output:
+    reader = csv.DictReader(tsv_input, delimiter="\t")
+
+    writer = csv.DictWriter(tsv_output, delimiter="\t", lineterminator='\n', fieldnames=reader.fieldnames)
+
+    writer.writeheader()
+    for row in reader:
+        writer.writerow(update_row(row))
+
+os.replace(out_file, filename)  # you can comment this out if you want to inspect the new file first
+
+print("Now click 'Apply' in 'Page Setup'.")


### PR DESCRIPTION
This is based on the advice given by SylvainLS in reply to my ["Instruction Maker renders Dark Blue too darkly"](https://forum.bricklink.com/viewtopic.php?f=4&t=8853#p27895) post on the [BrickLink Studio](https://www.bricklink.com/v3/studio/download.page) Forum.

> "you may try tuning Studio’s colours.  (Page Design > Page Setup, there’s a small “Edit” link next to “PARTS COLOR TABLE” at the bottom of the dialog.  It opens a TSV (tab-separated value) file in your text editor.)"

Editing the file manually was very slightly fiddly, I wanted a reproducible process so I scripted it!

You still have to go to `Page Setup` and click `Apply` to get Studio to read the updated file...

![image](https://user-images.githubusercontent.com/52038/227805114-dca7a31e-798d-4ff9-98f9-a7ddc6baec48.png)


...but you don't actually have to click `Edit`, or manually edit the `CustomColorDefinition.txt` file anymore.